### PR TITLE
Allow build failure propogation

### DIFF
--- a/get_coverage_for_challenge.sh
+++ b/get_coverage_for_challenge.sh
@@ -11,6 +11,14 @@ CHALLENGE_ID=$1
 NODEJS_TEST_REPORT_JSON_FILE="${SCRIPT_CURRENT_DIR}/coverage/coverage-summary.json"
 NODEJS_CODE_COVERAGE_INFO="${SCRIPT_CURRENT_DIR}/coverage.tdl"
 
+### Guard clause to check for invalid CHALLENGE_ID
+
+if [[ ! -e "${SCRIPT_CURRENT_DIR}/lib/solutions/${CHALLENGE_ID}" ]]; then
+   echo "" > ${NODEJS_CODE_COVERAGE_INFO}
+   echo "The provided CHALLENGE_ID: '${CHALLENGE_ID}' isn't valid, aborting process..."
+   exit 1
+fi
+
 ( cd ${SCRIPT_CURRENT_DIR} && npm install && npm run coverage || true 1>&2 )
 
 [ -e ${NODEJS_CODE_COVERAGE_INFO} ] && rm ${NODEJS_CODE_COVERAGE_INFO}


### PR DESCRIPTION
Guard clause added to coverage script to prevent detect invalid CHALLENGE_ID and abort process with exit code 1

Linked to https://github.com/julianghionoiu/dpnt-coverage/pull/34 and https://github.com/julianghionoiu/dpnt-coverage/issues/35
